### PR TITLE
[#154332832] Expand backup metadata

### DIFF
--- a/backups.go
+++ b/backups.go
@@ -16,16 +16,20 @@ package composeapi
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // Backup structure
 type Backup struct {
-	ID           string `json:"id"`
-	Deploymentid string `json:"deployment_id"`
-	Name         string `json:"name"`
-	Type         string `json:"type"`
-	Status       string `json:"status"`
-	DownloadLink string `json:"download_link"`
+	ID             string    `json:"id"`
+	Deploymentid   string    `json:"deployment_id"`
+	Name           string    `json:"name"`
+	Type           string    `json:"type"`
+	Status         string    `json:"status"`
+	IsDownloadable bool      `json:"is_downloadable"`
+	IsRestorable   bool      `json:"is_restorable"`
+	CreatedAt      time.Time `json:"created_at"`
+	DownloadLink   string    `json:"download_link"`
 }
 
 // backupsResponse is used to represent and remove the JSON+HAL Embedded wrapper


### PR DESCRIPTION
## What

Include more JSON API fields from the in this library's struct. We need `CreatedAt` and `IsRestorable` for our restore-from-backup work on the Compose broker. We've added `IsDownloadable` for completeness and to increase the chances of this getting merged into upstream.

## How to review

We've checked that this deserialises the API payloads (particularly the time format.) Code review should suffice.

## Who can review

Not @46bit @LeePorte 